### PR TITLE
Use miniLM-V6-L2 as the sentence embedding model

### DIFF
--- a/src/front_end/api/APIModel.py
+++ b/src/front_end/api/APIModel.py
@@ -21,7 +21,7 @@ class APIModel:
                     "dialoGPT": "../../../models/DialoGPT-small",
                     "t5": "../../../models/t5-small",
                     "bert": "../../../models/bert-base-cased-squad2",
-                    "mpnet": "../../../models/all-mpnet-base-v2",
+                    "miniLM": "../../../models/all-MiniLM-L6-v2",
                     "t5-e2e": "../../../models/t5-small-e2e-qg",
                     "intent": "../../../models/intent.sav",
                 },
@@ -29,7 +29,7 @@ class APIModel:
                     "dialoGPT": "../../../models/DialoGPT-medium",
                     "t5": "../../../models/t5-base",
                     "bert": "../../../models/bert-base-cased-squad2",
-                    "mpnet": "../../../models/all-mpnet-base-v2",
+                    "miniLM": "../../../models/all-MiniLM-L6-v2",
                     "t5-e2e": "../../../models/t5-base-e2e-qg",
                     "intent": "../../../models/intent.sav",
                 },
@@ -37,25 +37,25 @@ class APIModel:
                     "dialoGPT": "../../../models/DialoGPT-medium",
                     "t5": "../../../models/t5-large",
                     "bert": "../../../models/bert-base-cased-squad2",
-                    "mpnet": "../../../models/all-mpnet-base-v2",
+                    "miniLM": "../../../models/all-MiniLM-L6-v2",
                     "t5-e2e": "../../../models/t5-base-e2e-qg",
                     "intent": "../../../models/intent.sav",
                 },
-                "xlarge": {
+                "x-large": {
                     "dialoGPT": "../../../models/DialoGPT-large",
                     "t5": "../../../models/t5-large",
                     "bert": "../../../models/bert-base-cased-squad2",
-                    "mpnet": "../../../models/all-mpnet-base-v2",
+                    "miniLM": "../../../models/all-MiniLM-L6-v2",
                     "t5-e2e": "../../../models/t5-base-e2e-qg",
                     "intent": "../../../models/intent.sav",
                 }
             },
-            "selected_flavor": "medium",
+            "selected_flavor": "large",
             "use_cuda": {
                 "dialoGPT": True,
-                "t5": True,
-                "t5-e2e": False,
-                "mpnet": True
+                "t5": False,
+                "t5-e2e": True,
+                "miniLM": False
             }
         }
         self.model = MUKALMA(self.params)

--- a/src/models/mukalma/mukalma.py
+++ b/src/models/mukalma/mukalma.py
@@ -12,7 +12,7 @@
 # Importing Models
 from ...util_models.DialoGPTController import DialoGPTController
 from src.util_models.T5.T5ClozeController import T5ClozeController, getMaskToken
-from ...util_models.MpNet import MpNet
+from ...util_models.SentenceModel import SentenceModel
 from ...util_models.T5.T5ForQuestionGeneration import T5ForQuestionGeneration
 
 # Importing NLU Components
@@ -32,15 +32,13 @@ class MUKALMA:
         cuda.empty_cache()
         print(f"{self.TAG}: CUDA GPU is {'not' if not cuda.is_available() else ''} available on this machine")
 
-        self.knowledge_db = KnowledgeSource()
-
         # Parameter Configurations
         self.flavor_selected = params["selected_flavor"]
         self.flavor_config = params["flavors"][self.flavor_selected]
         self.model_flavors = params["flavors"]
         self.cuda_use = params["use_cuda"]
 
-        self.sentence_model = MpNet(self.flavor_config["mpnet"], use_cuda=self.cuda_use["mpnet"])
+        self.sentence_model = SentenceModel(self.flavor_config["miniLM"], use_cuda=self.cuda_use["miniLM"])
         
         self.intentRecognizer = IntentRecognizer(model_path=self.flavor_config["intent"])
 
@@ -53,6 +51,9 @@ class MUKALMA:
 
         self.cloze_model = T5ClozeController(self.flavor_config["t5"], use_cuda=self.cuda_use["t5"], num_responses=3)
         self.cloze_model.initialize_model()
+
+        # Initialize Knowledge Source using the Sentence Embedding Model of choice
+        self.knowledge_db = KnowledgeSource(self.sentence_model.model)
 
         # Keeps track of the topic that is currently being talked about
         self.topic_str = ""

--- a/src/util_models/SentenceModel.py
+++ b/src/util_models/SentenceModel.py
@@ -2,7 +2,7 @@
   MUKALMA - A Knowledge-Powered Conversational Agent
   Project Id: F21-20-R-KBCAgent
 
-  MpNet model controller class
+  SentenceModel model controller class
   - This model provides sentence similarity to a high accuracy level.
   - Computes sentence embeddings, especially useful since similarity scores aren't drastically affected by
   a disparity in the length of input sentences.
@@ -30,9 +30,9 @@ def softmax(x):
     return t_x / t_x.sum(axis=0)
 
 
-class MpNet:
+class SentenceModel:
     def __init__(self, model_path='../../../models/all-mpnet-base-v2', use_cuda=False):
-        self.TAG = 'MpNet'
+        self.TAG = 'SentenceModel'
         self.model = None
 
         self.device = 'cuda' if use_cuda and cuda.is_available() else 'cpu'


### PR DESCRIPTION
## Change Description

According to [this leaderboard](https://www.sbert.net/docs/pretrained_models.html) for Sentence Embedding models, specifically used for sentence/document similarity, ```all-mpnet-base-v2```, the sentence embedding model being used previously, is the most accurate one. However, ```all-miniLM-V6-L2``` peforms closely in terms of accuracy, but achieves that while being 5x faster. This makes it a suitable option for replacing TF-IDF 's use for selecting the most relevant paragraph from a given document in ```KnowledgeSource```.

Additionally, due to its comparable performance with MpNet, MiniLM also replaces MpNet's use in MUKALMA as a fallback when Question Answering fails to yield an answer