### PR TITLE
Add Flair's POS Tagger

### DIFF
--- a/src/models/mukalma/mukalma.py
+++ b/src/models/mukalma/mukalma.py
@@ -9,14 +9,16 @@
     - This model should be used for generating human-like dialog grounded on knowledge.
 """
 
+
 # Importing Models
 from ...util_models.DialoGPTController import DialoGPTController
 from src.util_models.T5.T5ClozeController import T5ClozeController, getMaskToken
 from ...util_models.SentenceModel import SentenceModel
 from ...util_models.T5.T5ForQuestionGeneration import T5ForQuestionGeneration
+from ...util_models.FlairPOSTagger import FlairPOSTagger
 
 # Importing NLU Components
-from .nlu.partsOfSpeech import get_pos_with_types, get_nouns, match_questions, truecasing_by_pos, fix_sentence
+from .nlu.partsOfSpeech import get_nouns, match_questions, truecasing_by_pos, fix_sentence
 from .nlu.intentRecognition import IntentRecognizer
 
 from .KnowledgeSource import KnowledgeSource
@@ -52,6 +54,8 @@ class MUKALMA:
         self.cloze_model = T5ClozeController(self.flavor_config["t5"], use_cuda=self.cuda_use["t5"], num_responses=3)
         self.cloze_model.initialize_model()
 
+        self.tagger = FlairPOSTagger('flair/pos-english-fast')
+
         # Initialize Knowledge Source using the Sentence Embedding Model of choice
         self.knowledge_db = KnowledgeSource(self.sentence_model.model)
 
@@ -62,7 +66,7 @@ class MUKALMA:
         pass
 
     def __extract_topic(self, message):
-        pos_list = get_pos_with_types(message)
+        pos_list = self.tagger.get_pos_tags(message)
         pos_words = []
         prev_type = None
         for pos in pos_list:

--- a/src/models/mukalma/mukalma.py
+++ b/src/models/mukalma/mukalma.py
@@ -231,13 +231,13 @@ class MUKALMA:
         # Get a list of topics that may have been mentioned in the message
         topics = self.__extract_topic(message)
 
-        print(f"TOPIC SEARCH STRING: {topics}")
+        print(f"MESSAGE KEYWORDS: {topics}")
 
         # If the message talks about a new topic...
         # Request Knowledge DB to fetch data relevant to the current message, update the db
         # and finally, return the most relevant document for this message
         cur_turn_knowledge, cur_turn_knowledge_tok = "", []
-        if len(topics) != "":
+        if len(topics) != 0:
             cur_turn_knowledge_tok = self.knowledge_db.fetch_topic_data(topics, message)
             cur_turn_knowledge = ' '.join(cur_turn_knowledge_tok)
 

--- a/src/util_models/FlairPOSTagger.py
+++ b/src/util_models/FlairPOSTagger.py
@@ -1,0 +1,38 @@
+"""
+  MUKALMA - A Knowledge-Powered Conversational Agent
+  Project Id: F21-20-R-KBCAgent
+
+  Wrapper class for the Flair POS tagger - one of the top ranked POS taggers across multiple metrics
+
+  @Author: Muhammad Farjad Ilyas
+  @Date: 29th March 2022
+"""
+
+from rich.console import Console
+from pathlib import Path
+
+# Flair imports for POS tagging
+import flair
+from flair.data import Sentence
+from flair.models import SequenceTagger
+
+# Change the cache directory for Flair models to one within this project's model directory
+flair.cache_root = Path("../../../models/.flair")
+console = Console(record=True)
+
+
+class FlairPOSTagger:
+    def __init__(self, model_path='flair/pos-english-fast'):
+        self.TAG = 'FlairPOSTagger'
+
+        console.log(f"""[{self.TAG}]: Loading {model_path}...\n""")
+        self.model = SequenceTagger.load(model_path)
+
+    def get_pos_tags(self, message):
+        sentence = Sentence(message)
+        self.model.predict(sentence)
+        toks = sentence.tokens
+        tags = []
+        for idx, entity in enumerate(sentence.get_spans('pos')):
+            tags.append((toks[idx].text, entity.get_labels()[0].value))
+        return tags


### PR DESCRIPTION
- This tagger outperforms the NLTK POS tagger being used by MUKALMA. For instance, on the WSJ corpus, it yields an accuracy of 97.9% vs NLTK's 94%
- Practically, replacing NLTK with Flair's POS Tagger in MUKALMA is useful since it reduces the number of False Positives in Noun Tagging and is more capable of correctly tagging compound words as Nouns, which is important for keyword extraction from a message
- Flair is significantly slower, but the improvement in accuracy seems worth it