### PR TITLE
Use ThreadPool for processing input

### DIFF
--- a/src/api/APIModel.py
+++ b/src/api/APIModel.py
@@ -9,12 +9,13 @@
 
 # Imports
 from ..mukalma.mukalma import MUKALMA
-from threading import Thread
+from concurrent.futures import ThreadPoolExecutor
 
 
 # Class Definition
 class APIModel:
     def __init__(self, progress_update_queue):
+        self.executor = ThreadPoolExecutor(1)
         self.params = {
             "flavors": {
                 "small": {
@@ -66,10 +67,7 @@ class APIModel:
         self.model = MUKALMA(self.params, progress_update_queue)
         
     def reply(self, message):
-        # Spawn a thread to asynchronously generate a response for the message received
-        t = Thread(target=self.model.get_response, args=(message, ))
-        t.daemon = True
-        t.start()
+        self.executor.submit(self.model.get_response, message)
         return {}
 
     def exit(self):


### PR DESCRIPTION
Instead of spawning a new thread everytime a new response has to be
generated, associate a thread pool comprising a single thread with
APIModel so a new thread doesn't have to be spawned repeatedly when
a response has to be generated.